### PR TITLE
Remove event.defer from storage timeout

### DIFF
--- a/governor/base.py
+++ b/governor/base.py
@@ -51,7 +51,6 @@ class GovernorEventHandler(Object):
                 retries += 1
         else:
             logging.warning("Unable to load Events, Deferring Action.")
-            event.defer()
             return
 
         for event_data in events_data:


### PR DESCRIPTION
This commit fixes issue #2. Event defer was
included so that the created event in storage
would still be addressed. But it failed because
it was defering the action event not the actual
event in storage which the action would read.

Therefore the event written in storage will be
addressed the next time the charm is woken up
through an event action..